### PR TITLE
Run tests as part of preview/updates

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,6 +2,7 @@ import * as pulumi from "@pulumi/pulumi";
 import * as awsx from "@pulumi/awsx";
 import * as eks from "@pulumi/eks";
 import * as k8s from "@pulumi/kubernetes";
+import { runTests } from "./test";
 
 const name = "helloworld";
 
@@ -16,3 +17,6 @@ export const cluster = new eks.Cluster(name, {
         storageClasses: "gp2",
         deployDashboard: false,
     });
+
+// Finally, run the unit tests to check our deployment (during previews and updates).
+runTests();

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,0 +1,28 @@
+import * as fs from 'fs';
+import * as Mocha from 'mocha';
+import * as path from 'path';
+import * as pulumi from '@pulumi/pulumi';
+
+// runTests executes all test files (*.ts) in the current directory.
+export function runTests() {
+    // Create a new Mocha test runner. We set the timeout to 30 minutes because many
+    // resources (like EKS) take a long time to provision.
+    const mocha = new Mocha({ timeout: 1000*60*30 });
+
+    // Only keep the .ts files, and skip this file (index.ts).
+    const testDir = __dirname;
+    fs.readdirSync(testDir).
+        filter(file => file.endsWith('.ts') && file !== 'index.ts').
+            forEach(file => { mocha.addFile(path.join(testDir, file)); });
+
+    // Now run all of the tests that we've registered, and exit the process if any fail.
+    console.log(`Running Mocha Tests: ${mocha.files}`);
+    mocha.reporter("spec").run(failures => {
+        process.exitCode = failures ? 1 : 0;
+    });
+}
+
+// promise returns a resource output's value, even if it's undefined.
+export function promise<T>(output: pulumi.Output<T>): Promise<T | undefined> {
+    return (output as any).promise() as Promise<T>;
+}

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,33 +1,10 @@
-
-process.env.PULUMI_TEST_MODE = 'true';
-process.env.PULUMI_NODEJS_STACK = 'stack-name';
-process.env.PULUMI_NODEJS_PROJECT = 'infra-eks';
-
-import * as yaml from 'js-yaml';
 import { expect } from 'chai';
-import * as pulumi from "@pulumi/pulumi";
-import 'mocha';
-
-const pulumiConfig = yaml.safeLoad(require('fs').readFileSync('./Pulumi.unit-test.yaml', 'utf8'));
-process.env.PULUMI_CONFIG = JSON.stringify(pulumiConfig.config);
-
-import * as index from '../index';
+import { promise } from './';
+import { cluster } from '../';
 
 describe('#EKS Cluster Deployment', () => {
-    let cluster = index.cluster;
-    it('Should Deploy EKS Cluster', (done) => {
-        cluster.eksCluster.version.apply(([version]) => asyncDone(() => {
-            expect(version).to.equals('should fail');
-        }, done));
+    it('Should Deploy EKS Cluster', async () => {
+        const version = await promise(cluster.eksCluster.version);
+        expect(version).to.equals("should fail");
     });
 });
-
-const asyncDone = (testFn: Function, done: Function) => {
-    try {
-        testFn();
-
-        done();
-    } catch (err) {
-        done(err);
-    }
-}


### PR DESCRIPTION
These tests depend on two things that aren't available in
PULUMI_TEST_MODE:

1) Resource functions (like aws.getRegion()).
2) Resource outputs (like the EKS cluster's version).

Instead of running without the Pulumi CLI in the picture --
which is necessary for (1) and (2) to work -- we can instead
run the tests from within the Pulumi program itself.

This has the extra benefit that tests will be run as part of
any update, and they are properly orchestrated with respect
to the engine's activities around previews and updates.

To run the tests, simply run

    $ pulumi preview

or just do an update as usual

    $ pulumi up

and you will see the test output emitted to the console.

We plan on reconciling this with PULUMI_TEST_MODE, and removing
the need to use the promise<T> function in here, as part of
https://github.com/pulumi/pulumi/issues/2287.